### PR TITLE
Polling ubi images - fixing edge case where sha files are not present

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -89,7 +89,13 @@ jobs:
 
           # Build Image
           current_build_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/ubi-minimal)
-          previous_build_sha256_image_hash_code=$(cat ${{ github.workspace }}/${{ env.UBI_BUILD_SHA256_FILENAME }})
+
+          previous_build_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_BUILD_SHA256_FILENAME }}
+          previous_build_sha256_image_hash_code=""
+          if [ -f "$previous_build_sha256_image_hash_code_filepath" ]; then
+            previous_build_sha256_image_hash_code=$(cat $previous_build_sha256_image_hash_code_filepath)
+          fi
+
           ubi_image_current_hash_codes+=("node-build" $current_build_sha256_image_hash_code)
 
           if [ "$previous_build_sha256_image_hash_code" != "$current_build_sha256_image_hash_code" ]; then
@@ -98,7 +104,13 @@ jobs:
 
           # Run Image
           current_run_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/ubi-minimal)
-          previous_run_sha256_image_hash_code=$(cat ${{ github.workspace }}/${{ env.UBI_RUN_SHA256_FILENAME }})
+
+          previous_run_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_RUN_SHA256_FILENAME }}
+          previous_run_sha256_image_hash_code=""
+          if [ -f "$previous_run_sha256_image_hash_code_filepath" ]; then
+            previous_run_sha256_image_hash_code=$(cat $previous_run_sha256_image_hash_code_filepath)
+          fi
+
           ubi_image_current_hash_codes+=("node-run" $current_run_sha256_image_hash_code)
 
           if [ "$previous_run_sha256_image_hash_code" != "$current_run_sha256_image_hash_code" ]; then
@@ -107,7 +119,13 @@ jobs:
 
           # Run Image Node.js 16
           current_run_nodejs_16_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/nodejs-16-minimal)
-          previous_run_nodejs_16_sha256_image_hash_code=$(cat ${{ github.workspace }}/${{ env.UBI_RUN_NODEJS_16_SHA256_FILENAME }})
+
+          previous_run_nodejs_16_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_RUN_NODEJS_16_SHA256_FILENAME }}
+          previous_run_nodejs_16_sha256_image_hash_code=""
+          if [ -f "$previous_run_nodejs_16_sha256_image_hash_code_filepath" ]; then
+            previous_run_nodejs_16_sha256_image_hash_code=$(cat $previous_run_nodejs_16_sha256_image_hash_code_filepath)
+          fi
+
           ubi_image_current_hash_codes+=("node-16-run" $current_run_nodejs_16_sha256_image_hash_code)
 
           if [ "$previous_run_nodejs_16_sha256_image_hash_code" != "$current_run_nodejs_16_sha256_image_hash_code" ]; then
@@ -116,7 +134,13 @@ jobs:
 
           # Run Image Node.js 18
           current_run_nodejs_18_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/nodejs-18-minimal)
-          previous_run_nodejs_18_sha256_image_hash_code=$(cat ${{ github.workspace }}/${{ env.UBI_RUN_NODEJS_18_SHA256_FILENAME }})
+
+          previous_run_nodejs_18_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_RUN_NODEJS_18_SHA256_FILENAME }}
+          previous_run_nodejs_18_sha256_image_hash_code=""
+          if [ -f "$previous_run_nodejs_18_sha256_image_hash_code_filepath" ]; then
+              previous_run_nodejs_18_sha256_image_hash_code=$(cat $previous_run_nodejs_18_sha256_image_hash_code_filepath)
+          fi
+
           ubi_image_current_hash_codes+=("node-18-run" $current_run_nodejs_18_sha256_image_hash_code)
 
           if [ "$previous_run_nodejs_18_sha256_image_hash_code" != "$current_run_nodejs_18_sha256_image_hash_code" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .bin/
 build/
-build-nodejs-18
-build-nodejs-16
+build-nodejs-18/
+build-nodejs-16/


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

In case of there are no sha files, as for example on the current release, the action tries to read a file that does not exists and as a result throws an error. This PR adds a check if the file exists before reading it. In case the file does not exist, sets the value of the sha variable to an empty string in order to be updated on the next steps

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
