### PR TITLE
Add Java Run Images

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,6 +26,9 @@ env:
   UBI_RUN_SHA256_FILENAME: run.oci.sha256
   UBI_RUN_NODEJS_16_SHA256_FILENAME: run-nodejs-16.oci.sha256
   UBI_RUN_NODEJS_18_SHA256_FILENAME: run-nodejs-18.oci.sha256
+  UBI_RUN_JAVA_8_SHA256_FILENAME: run-java-8.oci.sha256
+  UBI_RUN_JAVA_11_SHA256_FILENAME: run-java-11.oci.sha256
+  UBI_RUN_JAVA_17_SHA256_FILENAME: run-java-17.oci.sha256
 
 jobs:
   poll_ubi_images:
@@ -79,6 +82,36 @@ jobs:
           repo: ${{ github.repository }}
           output_path: "/github/workspace/${{ env.UBI_RUN_NODEJS_18_SHA256_FILENAME }}"
           token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+      - name: Find and Download Previous run Java 8 sha256 image hash code
+        id: fetch_previous_run_java_8_sha256_image_hash_code
+        uses: paketo-buildpacks/github-config/actions/release/find-and-download-asset@main
+        with:
+          asset_pattern: "${{ env.UBI_RUN_JAVA_8_SHA256_FILENAME }}"
+          search_depth: 1
+          repo: ${{ github.repository }}
+          output_path: "/github/workspace/${{ env.UBI_RUN_JAVA_8_SHA256_FILENAME }}"
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+      - name: Find and Download Previous run Java 11 sha256 image hash code
+        id: fetch_previous_run_java_11_sha256_image_hash_code
+        uses: paketo-buildpacks/github-config/actions/release/find-and-download-asset@main
+        with:
+          asset_pattern: "${{ env.UBI_RUN_JAVA_11_SHA256_FILENAME }}"
+          search_depth: 1
+          repo: ${{ github.repository }}
+          output_path: "/github/workspace/${{ env.UBI_RUN_JAVA_11_SHA256_FILENAME }}"
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}  
+
+      - name: Find and Download Previous run Java 17 sha256 image hash code
+        id: fetch_previous_run_java_17_sha256_image_hash_code
+        uses: paketo-buildpacks/github-config/actions/release/find-and-download-asset@main
+        with:
+          asset_pattern: "${{ env.UBI_RUN_JAVA_17_SHA256_FILENAME }}"
+          search_depth: 1
+          repo: ${{ github.repository }}
+          output_path: "/github/workspace/${{ env.UBI_RUN_JAVA_17_SHA256_FILENAME }}"
+          token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}                                  
 
       - name: Compare previous and current sha256 hash codes
         id: compare_previous_and_current_sha256_hash_codes
@@ -147,6 +180,52 @@ jobs:
             ubi_images_need_update+=("node-18-run")
           fi
 
+          # Run Image Java 8
+          current_run_java_8_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/openjdk-8-runtime)
+
+          previous_run_java_8_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_RUN_JAVA_8_SHA256_FILENAME }}
+          previous_run_java_8_sha256_image_hash_code=""
+          if [ -f "$previous_run_java_8_sha256_image_hash_code_filepath" ]; then
+              previous_run_java_8_sha256_image_hash_code=$(cat $previous_run_java_8_sha256_image_hash_code_filepath)
+          fi
+
+          ubi_image_current_hash_codes+=("java-8-run" $current_run_java_8_sha256_image_hash_code)
+
+          if [ "$previous_run_java_8_sha256_image_hash_code" != "$current_run_java_8_sha256_image_hash_code" ]; then
+            ubi_images_need_update+=("java-8-run")
+          fi
+
+          # Run Image Java 11
+          current_run_java_11_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/openjdk-11-runtime)
+
+          previous_run_java_11_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_RUN_JAVA_11_SHA256_FILENAME }}
+          previous_run_java_11_sha256_image_hash_code=""
+          if [ -f "$previous_run_java_11_sha256_image_hash_code_filepath" ]; then
+              previous_run_java_11_sha256_image_hash_code=$(cat $previous_run_java_11_sha256_image_hash_code_filepath)
+          fi
+
+          ubi_image_current_hash_codes+=("java-11-run" $current_run_java_11_sha256_image_hash_code)
+
+          if [ "$previous_run_java_11_sha256_image_hash_code" != "$current_run_java_11_sha256_image_hash_code" ]; then
+            ubi_images_need_update+=("java-11-run")
+          fi
+          
+          # Run Image Java 17
+          current_run_java_17_sha256_image_hash_code=$(skopeo inspect --format "{{.Digest}}" docker://registry.access.redhat.com/ubi8/openjdk-17-runtime)
+
+          previous_run_java_17_sha256_image_hash_code_filepath=${{ github.workspace }}/${{ env.UBI_RUN_JAVA_17_SHA256_FILENAME }}
+          previous_run_java_17_sha256_image_hash_code=""
+          if [ -f "$previous_run_java_17_sha256_image_hash_code_filepath" ]; then
+              previous_run_java_17_sha256_image_hash_code=$(cat $previous_run_java_17_sha256_image_hash_code_filepath)
+          fi
+
+          ubi_image_current_hash_codes+=("java-17-run" $current_run_java_17_sha256_image_hash_code)
+
+          if [ "$previous_run_java_17_sha256_image_hash_code" != "$current_run_java_17_sha256_image_hash_code" ]; then
+            ubi_images_need_update+=("java-17-run")
+          fi          
+
+          # Print updates and hashcodes.
           json_ubi_images_need_update=$(jq --compact-output --null-input '$ARGS.positional' --args -- "${ubi_images_need_update[@]}")
           printf "ubi_images_need_update=%s\n" "${json_ubi_images_need_update}" >> "$GITHUB_OUTPUT"
 
@@ -219,7 +298,6 @@ jobs:
           path: hash-codes/build/run.oci.sha256
 
       ## nodejs 16 run image
-
       - name: Upload nodejs 16 run image
         uses: actions/upload-artifact@v3
         with:
@@ -269,6 +347,84 @@ jobs:
           name: current-nodejs-18-run-image-hash-code
           path: hash-codes/build-nodejs-18/run.oci.sha256
 
+
+      ## java 8 run image
+      - name: Upload java 8 run image
+        uses: actions/upload-artifact@v3
+        with:
+          name: current-java-8-run-image
+          path: ./build-java-8/run.oci
+
+      - name: Get java 8 run image hash code
+        run: |
+          mkdir -p hash-codes/build-java-8
+
+          ubi_image_current_hash_codes=($(echo '${{ needs.poll_ubi_images.outputs.ubi_image_current_hash_codes }}' | jq -r '.[]'))
+
+          for ((i = 0; i < ${#ubi_image_current_hash_codes[@]}; i += 2)); do
+            if [ "${ubi_image_current_hash_codes[i]}" == "java-8-run" ]; then
+              echo ${ubi_image_current_hash_codes[i + 1]} > hash-codes/build-java-8/run.oci.sha256
+            fi
+          done
+
+      - name: Upload java 8 run image hash code
+        uses: actions/upload-artifact@v3
+        with:
+          name: current-java-8-run-image-hash-code
+          path: hash-codes/build-java-8/run.oci.sha256    
+          
+
+      ## java 11 run image
+      - name: Upload java 11 run image
+        uses: actions/upload-artifact@v3
+        with:
+          name: current-java-11-run-image
+          path: ./build-java-11/run.oci
+
+      - name: Get java 11 run image hash code
+        run: |
+          mkdir -p hash-codes/build-java-11
+
+          ubi_image_current_hash_codes=($(echo '${{ needs.poll_ubi_images.outputs.ubi_image_current_hash_codes }}' | jq -r '.[]'))
+
+          for ((i = 0; i < ${#ubi_image_current_hash_codes[@]}; i += 2)); do
+            if [ "${ubi_image_current_hash_codes[i]}" == "java-11-run" ]; then
+              echo ${ubi_image_current_hash_codes[i + 1]} > hash-codes/build-java-11/run.oci.sha256
+            fi
+          done
+
+      - name: Upload java 11 run image hash code
+        uses: actions/upload-artifact@v3
+        with:
+          name: current-java-11-run-image-hash-code
+          path: hash-codes/build-java-11/run.oci.sha256
+          
+
+      ## java 8 run image
+      - name: Upload java 17 run image
+        uses: actions/upload-artifact@v3
+        with:
+          name: current-java-17-run-image
+          path: ./build-java-17/run.oci
+
+      - name: Get java 17 run image hash code
+        run: |
+          mkdir -p hash-codes/build-java-17
+
+          ubi_image_current_hash_codes=($(echo '${{ needs.poll_ubi_images.outputs.ubi_image_current_hash_codes }}' | jq -r '.[]'))
+
+          for ((i = 0; i < ${#ubi_image_current_hash_codes[@]}; i += 2)); do
+            if [ "${ubi_image_current_hash_codes[i]}" == "java-17-run" ]; then
+              echo ${ubi_image_current_hash_codes[i + 1]} > hash-codes/build-java-17/run.oci.sha256
+            fi
+          done
+
+      - name: Upload java 17 run image hash code
+        uses: actions/upload-artifact@v3
+        with:
+          name: current-java-17-run-image-hash-code
+          path: hash-codes/build-java-17/run.oci.sha256          
+
   test:
     name: Acceptance Test
     needs: [create_stack]
@@ -287,6 +443,9 @@ jobs:
           mkdir -p build
           mkdir -p build-nodejs-16
           mkdir -p build-nodejs-18
+          mkdir -p build-java-8
+          mkdir -p build-java-11
+          mkdir -p build-java-17
 
       - name: Download Build Image
         uses: actions/download-artifact@v3
@@ -311,6 +470,24 @@ jobs:
         with:
           name: current-nodejs-18-run-image
           path: build-nodejs-18
+
+      - name: Download java-8 Run Image
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-8-run-image
+          path: build-java-8
+
+      - name: Download java-11 Run Image
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-11-run-image
+          path: build-java-11
+
+      - name: Download java-17 Run Image
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-17-run-image
+          path: build-java-17
 
       - name: Run Acceptance Tests
         run: scripts/test.sh
@@ -388,6 +565,42 @@ jobs:
           name: current-nodejs-18-run-image-hash-code
           path: build-nodejs-18
 
+      - name: Download java-8 Run Image
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-8-run-image
+          path: build-java-8
+
+      - name: Download java-8 Run Image hash code
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-8-run-image-hash-code
+          path: build-java-8
+
+      - name: Download java-11 Run Image
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-11-run-image
+          path: build-java-11
+
+      - name: Download java-11 Run Image hash code
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-11-run-image-hash-code
+          path: build-java-11
+
+      - name: Download java-17 Run Image
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-17-run-image
+          path: build-java-17
+
+      - name: Download java-17 Run Image hash code
+        uses: actions/download-artifact@v3
+        with:
+          name: current-java-17-run-image-hash-code
+          path: build-java-17
+
       - name: Increment Tag
         if: github.event.inputs.version == ''
         id: semver
@@ -437,6 +650,15 @@ jobs:
           release_body+="Run Node.js 18: paketocommunity/run-nodejs-18-${{ steps.repo_name.outputs.registry_repo_name }}:${{ steps.tag.outputs.tag }}"
           release_body+=" \<br \/\> "
 
+          release_body+="Run Java 8: paketocommunity/run-java-8-${{ steps.repo_name.outputs.registry_repo_name }}:${{ steps.tag.outputs.tag }}"
+          release_body+=" \<br \/\> "
+
+          release_body+="Run Java 11: paketocommunity/run-java-11-${{ steps.repo_name.outputs.registry_repo_name }}:${{ steps.tag.outputs.tag }}"
+          release_body+=" \<br \/\> "
+
+          release_body+="Run Java 17: paketocommunity/run-java-17-${{ steps.repo_name.outputs.registry_repo_name }}:${{ steps.tag.outputs.tag }}"
+          release_body+=" \<br \/\> "
+
           echo "release_body=${release_body}" >> "$GITHUB_OUTPUT"
 
       - name: Setup Release Assets
@@ -446,6 +668,36 @@ jobs:
             --arg tag "${{ steps.tag.outputs.tag }}" \
             --arg repo "${{ steps.repo_name.outputs.github_repo_name }}" \
             '[
+              {
+                "path": "build-java-8/run.oci",
+                "name": ($repo + "-" + $tag + "-" + "run-java-8.oci"),
+                "content_type": "application/gzip"
+              },
+              {
+                "path": "build-java-8/run.oci.sha256",
+                "name": ($repo + "-" + $tag + "-" + "run-java-8.oci.sha256"),
+                "content_type": "application/gzip"
+              },
+              {
+                "path": "build-java-11/run.oci",
+                "name": ($repo + "-" + $tag + "-" + "run-java-11.oci"),
+                "content_type": "application/gzip"
+              },
+              {
+                "path": "build-java-11/run.oci.sha256",
+                "name": ($repo + "-" + $tag + "-" + "run-java-11.oci.sha256"),
+                "content_type": "application/gzip"
+              },
+              {
+                "path": "build-java-17/run.oci",
+                "name": ($repo + "-" + $tag + "-" + "run-java-17.oci"),
+                "content_type": "application/gzip"
+              },
+              {
+                "path": "build-java-17/run.oci.sha256",
+                "name": ($repo + "-" + $tag + "-" + "run-java-17.oci.sha256"),
+                "content_type": "application/gzip"
+              },                            
               {
                 "path": "build-nodejs-16/run.oci",
                 "name": ($repo + "-" + $tag + "-" + "run-nodejs-16.oci"),

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -400,7 +400,7 @@ jobs:
           path: hash-codes/build-java-11/run.oci.sha256
           
 
-      ## java 8 run image
+      ## java 17 run image
       - name: Upload java 17 run image
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -19,6 +19,9 @@ jobs:
         echo "run_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
         echo "run_nodejs_16_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run-nodejs-16.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
         echo "run_nodejs_18_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run-nodejs-18.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "run_java_8_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run-java-8.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "run_java_11_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run-java-11.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
+        echo "run_java_17_download_url=$(jq -r '.release.assets[] | select(.name | endswith("run-java-17.oci")) | .url' "${GITHUB_EVENT_PATH}")" >> "$GITHUB_OUTPUT"
 
     - name: Checkout
       uses: actions/checkout@v3
@@ -49,6 +52,27 @@ jobs:
       with:
         url: ${{ steps.event.outputs.run_nodejs_18_download_url }}
         output: "/github/workspace/run-nodejs-18.oci"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download java-8 Run Image
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.run_java_8_download_url }}
+        output: "/github/workspace/run-java-8.oci"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download java-11 Run Image
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.run_java_11_download_url }}
+        output: "/github/workspace/run-java-11.oci"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+
+    - name: Download java-17 Run Image
+      uses: paketo-buildpacks/github-config/actions/release/download-asset@main
+      with:
+        url: ${{ steps.event.outputs.run_java_17_download_url }}
+        output: "/github/workspace/run-java-17.oci"
         token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
     - name: Get Registry Repo Name
@@ -94,6 +118,24 @@ jobs:
 
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-nodejs-18.oci" "docker://gcr.io/${GCR_PROJECT}/run-nodejs-18-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-nodejs-18.oci" "docker://gcr.io/${GCR_PROJECT}/run-nodejs-18-${{ steps.registry-repo.outputs.name }}:latest"
+
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-8.oci" "docker://${DOCKERHUB_ORG}/run-java-8-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-8.oci" "docker://${DOCKERHUB_ORG}/run-java-8-${{ steps.registry-repo.outputs.name }}:latest"
+
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-8.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-8-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-8.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-8-${{ steps.registry-repo.outputs.name }}:latest"
+
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-11.oci" "docker://${DOCKERHUB_ORG}/run-java-11-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-11.oci" "docker://${DOCKERHUB_ORG}/run-java-11-${{ steps.registry-repo.outputs.name }}:latest"
+
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-11.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-11-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-11.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-11-${{ steps.registry-repo.outputs.name }}:latest"
+
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-17.oci" "docker://${DOCKERHUB_ORG}/run-java-17-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-17.oci" "docker://${DOCKERHUB_ORG}/run-java-17-${{ steps.registry-repo.outputs.name }}:latest"
+
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-17.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-17-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-17.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-17-${{ steps.registry-repo.outputs.name }}:latest"
 
 
   failure:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 build/
 build-nodejs-18/
 build-nodejs-16/
+build-java-8/
+build-java-11/
+build-java-17/

--- a/init_test.go
+++ b/init_test.go
@@ -21,6 +21,9 @@ var stack struct {
 	RunImageID         string
 	RunNodejs16Archive string
 	RunNodejs18Archive string
+	RunJava8Archive    string
+	RunJava11Archive   string
+	RunJava17Archive   string
 }
 
 func by(_ string, f func()) { f() }
@@ -40,6 +43,9 @@ func TestAcceptance(t *testing.T) {
 
 	stack.RunNodejs16Archive = filepath.Join(root, "build-nodejs-16", "run.oci")
 	stack.RunNodejs18Archive = filepath.Join(root, "build-nodejs-18", "run.oci")
+	stack.RunJava8Archive = filepath.Join(root, "build-java-8", "run.oci")
+	stack.RunJava11Archive = filepath.Join(root, "build-java-11", "run.oci")
+	stack.RunJava17Archive = filepath.Join(root, "build-java-17", "run.oci")
 
 	SetDefaultEventuallyTimeout(30 * time.Second)
 

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -333,11 +333,11 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDateJava8).NotTo(BeZero())
 
-			Expect(file.Config.User).To(Equal("1002:1000"))
+			Expect(file.Config.User).To(Equal("1001:1000"))
 
 			Expect(image).To(SatisfyAll(
 				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1001:1000::/home/cnb:/bin/bash")),
 				HaveDirectory("/home/cnb"),
 			))
 
@@ -396,11 +396,11 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDateJava11).NotTo(BeZero())
 
-			Expect(file.Config.User).To(Equal("1002:1000"))
+			Expect(file.Config.User).To(Equal("1001:1000"))
 
 			Expect(image).To(SatisfyAll(
 				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1001:1000::/home/cnb:/bin/bash")),
 				HaveDirectory("/home/cnb"),
 			))
 
@@ -459,11 +459,11 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDateJava17).NotTo(BeZero())
 
-			Expect(file.Config.User).To(Equal("1002:1000"))
+			Expect(file.Config.User).To(Equal("1001:1000"))
 
 			Expect(image).To(SatisfyAll(
 				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
-				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1001:1000::/home/cnb:/bin/bash")),
 				HaveDirectory("/home/cnb"),
 			))
 

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -33,7 +33,7 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("builds base stack", func() {
-		var buildReleaseDate, runReleaseDate, runReleaseDateNodejs16, runReleaseDateNodejs18 time.Time
+		var buildReleaseDate, runReleaseDate, runReleaseDateNodejs16, runReleaseDateNodejs18, runReleaseDateJava8, runReleaseDateJava11, runReleaseDateJava17 time.Time
 
 		by("confirming that the build image is correct", func() {
 			dir := filepath.Join(tmpDir, "build-index")
@@ -269,6 +269,195 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 			runReleaseDateNodejs18, err = time.Parse(time.RFC3339, file.Config.Labels["io.buildpacks.stack.released"])
 			Expect(err).NotTo(HaveOccurred())
 			Expect(runReleaseDateNodejs18).NotTo(BeZero())
+
+			Expect(file.Config.User).To(Equal("1002:1000"))
+
+			Expect(image).To(SatisfyAll(
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveDirectory("/home/cnb"),
+			))
+
+			Expect(image).To(HaveFileWithContent("/etc/os-release", SatisfyAll(
+				ContainSubstring(`PRETTY_NAME="Red Hat Enterprise Linux 8.8 (Ootpa)"`),
+				ContainSubstring(`HOME_URL="https://github.com/paketo-community/ubi-base-stack"`),
+				ContainSubstring(`SUPPORT_URL="https://github.com/paketo-community/ubi-base-stack/blob/main/README.md"`),
+				ContainSubstring(`BUG_REPORT_URL="https://github.com/paketo-community/ubi-base-stack/issues/new"`),
+			)))
+		})
+
+		by("confirming that the run java-8 image is correct", func() {
+			dir := filepath.Join(tmpDir, "run-index-java-8")
+			err := os.Mkdir(dir, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive, err := os.Open(stack.RunNodejs16Archive)
+			Expect(err).NotTo(HaveOccurred())
+			defer archive.Close()
+
+			err = vacation.NewArchive(archive).Decompress(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			path, err := layout.FromPath(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			index, err := path.ImageIndex()
+			Expect(err).NotTo(HaveOccurred())
+
+			indexManifest, err := index.IndexManifest()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(indexManifest.Manifests).To(HaveLen(1))
+			Expect(indexManifest.Manifests[0].Platform).To(Equal(&v1.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			}))
+
+			image, err := index.Image(indexManifest.Manifests[0].Digest)
+			Expect(err).NotTo(HaveOccurred())
+
+			file, err := image.ConfigFile()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(file.Config.Labels).To(SatisfyAll(
+				HaveKeyWithValue("io.buildpacks.stack.id", "io.buildpacks.stacks.ubi8"),
+				HaveKeyWithValue("io.buildpacks.stack.description", "ubi8 java-8 image to support buildpacks"),
+				HaveKeyWithValue("io.buildpacks.stack.distro.name", "rhel"),
+				HaveKeyWithValue("io.buildpacks.stack.distro.version", "8.8"),
+				HaveKeyWithValue("io.buildpacks.stack.homepage", "https://github.com/paketo-community/ubi-base-stack"),
+				HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Community"),
+				HaveKeyWithValue("io.buildpacks.stack.metadata", MatchJSON("{}")),
+			))
+
+			runReleaseDateJava8, err = time.Parse(time.RFC3339, file.Config.Labels["io.buildpacks.stack.released"])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runReleaseDateJava8).NotTo(BeZero())
+
+			Expect(file.Config.User).To(Equal("1002:1000"))
+
+			Expect(image).To(SatisfyAll(
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveDirectory("/home/cnb"),
+			))
+
+			Expect(image).To(HaveFileWithContent("/etc/os-release", SatisfyAll(
+				ContainSubstring(`PRETTY_NAME="Red Hat Enterprise Linux 8.8 (Ootpa)"`),
+				ContainSubstring(`HOME_URL="https://github.com/paketo-community/ubi-base-stack"`),
+				ContainSubstring(`SUPPORT_URL="https://github.com/paketo-community/ubi-base-stack/blob/main/README.md"`),
+				ContainSubstring(`BUG_REPORT_URL="https://github.com/paketo-community/ubi-base-stack/issues/new"`),
+			)))
+		})
+
+		by("confirming that the run java-11 image is correct", func() {
+			dir := filepath.Join(tmpDir, "run-index-java-11")
+			err := os.Mkdir(dir, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive, err := os.Open(stack.RunNodejs16Archive)
+			Expect(err).NotTo(HaveOccurred())
+			defer archive.Close()
+
+			err = vacation.NewArchive(archive).Decompress(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			path, err := layout.FromPath(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			index, err := path.ImageIndex()
+			Expect(err).NotTo(HaveOccurred())
+
+			indexManifest, err := index.IndexManifest()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(indexManifest.Manifests).To(HaveLen(1))
+			Expect(indexManifest.Manifests[0].Platform).To(Equal(&v1.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			}))
+
+			image, err := index.Image(indexManifest.Manifests[0].Digest)
+			Expect(err).NotTo(HaveOccurred())
+
+			file, err := image.ConfigFile()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(file.Config.Labels).To(SatisfyAll(
+				HaveKeyWithValue("io.buildpacks.stack.id", "io.buildpacks.stacks.ubi8"),
+				HaveKeyWithValue("io.buildpacks.stack.description", "ubi8 java-11 image to support buildpacks"),
+				HaveKeyWithValue("io.buildpacks.stack.distro.name", "rhel"),
+				HaveKeyWithValue("io.buildpacks.stack.distro.version", "8.8"),
+				HaveKeyWithValue("io.buildpacks.stack.homepage", "https://github.com/paketo-community/ubi-base-stack"),
+				HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Community"),
+				HaveKeyWithValue("io.buildpacks.stack.metadata", MatchJSON("{}")),
+			))
+
+			runReleaseDateJava11, err = time.Parse(time.RFC3339, file.Config.Labels["io.buildpacks.stack.released"])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runReleaseDateJava11).NotTo(BeZero())
+
+			Expect(file.Config.User).To(Equal("1002:1000"))
+
+			Expect(image).To(SatisfyAll(
+				HaveFileWithContent("/etc/group", ContainSubstring("cnb:x:1000:")),
+				HaveFileWithContent("/etc/passwd", ContainSubstring("cnb:x:1002:1000::/home/cnb:/bin/bash")),
+				HaveDirectory("/home/cnb"),
+			))
+
+			Expect(image).To(HaveFileWithContent("/etc/os-release", SatisfyAll(
+				ContainSubstring(`PRETTY_NAME="Red Hat Enterprise Linux 8.8 (Ootpa)"`),
+				ContainSubstring(`HOME_URL="https://github.com/paketo-community/ubi-base-stack"`),
+				ContainSubstring(`SUPPORT_URL="https://github.com/paketo-community/ubi-base-stack/blob/main/README.md"`),
+				ContainSubstring(`BUG_REPORT_URL="https://github.com/paketo-community/ubi-base-stack/issues/new"`),
+			)))
+		})
+
+		by("confirming that the run java-17 image is correct", func() {
+			dir := filepath.Join(tmpDir, "run-index-java-17")
+			err := os.Mkdir(dir, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			archive, err := os.Open(stack.RunNodejs16Archive)
+			Expect(err).NotTo(HaveOccurred())
+			defer archive.Close()
+
+			err = vacation.NewArchive(archive).Decompress(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			path, err := layout.FromPath(dir)
+			Expect(err).NotTo(HaveOccurred())
+
+			index, err := path.ImageIndex()
+			Expect(err).NotTo(HaveOccurred())
+
+			indexManifest, err := index.IndexManifest()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(indexManifest.Manifests).To(HaveLen(1))
+			Expect(indexManifest.Manifests[0].Platform).To(Equal(&v1.Platform{
+				OS:           "linux",
+				Architecture: "amd64",
+			}))
+
+			image, err := index.Image(indexManifest.Manifests[0].Digest)
+			Expect(err).NotTo(HaveOccurred())
+
+			file, err := image.ConfigFile()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(file.Config.Labels).To(SatisfyAll(
+				HaveKeyWithValue("io.buildpacks.stack.id", "io.buildpacks.stacks.ubi8"),
+				HaveKeyWithValue("io.buildpacks.stack.description", "ubi8 java-17 image to support buildpacks"),
+				HaveKeyWithValue("io.buildpacks.stack.distro.name", "rhel"),
+				HaveKeyWithValue("io.buildpacks.stack.distro.version", "8.8"),
+				HaveKeyWithValue("io.buildpacks.stack.homepage", "https://github.com/paketo-community/ubi-base-stack"),
+				HaveKeyWithValue("io.buildpacks.stack.maintainer", "Paketo Community"),
+				HaveKeyWithValue("io.buildpacks.stack.metadata", MatchJSON("{}")),
+			))
+
+			runReleaseDateJava17, err = time.Parse(time.RFC3339, file.Config.Labels["io.buildpacks.stack.released"])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runReleaseDateJava17).NotTo(BeZero())
 
 			Expect(file.Config.User).To(Equal("1002:1000"))
 

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -9,4 +9,7 @@ readonly ROOT_DIR="$(cd "${PROG_DIR}/.." && pwd)"
 bash $PROG_DIR/create-one.sh
 STACK_DIR=${ROOT_DIR}/stack-nodejs-16 BUILD_DIR=${ROOT_DIR}/build-nodejs-16 bash $PROG_DIR/create-one.sh
 STACK_DIR=${ROOT_DIR}/stack-nodejs-18 BUILD_DIR=${ROOT_DIR}/build-nodejs-18 bash $PROG_DIR/create-one.sh
+STACK_DIR=${ROOT_DIR}/stack-java-8 BUILD_DIR=${ROOT_DIR}/build-java-8 bash $PROG_DIR/create-one.sh
+STACK_DIR=${ROOT_DIR}/stack-java-11 BUILD_DIR=${ROOT_DIR}/build-java-11 bash $PROG_DIR/create-one.sh
+STACK_DIR=${ROOT_DIR}/stack-java-17 BUILD_DIR=${ROOT_DIR}/build-java-17 bash $PROG_DIR/create-one.sh
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,6 +8,9 @@ readonly STACK_DIR="$(cd "${PROG_DIR}/.." && pwd)"
 readonly OUTPUT_DIR="${STACK_DIR}/build"
 readonly OUTPUT_DIR_NODEJS16="${STACK_DIR}/build-nodejs-16"
 readonly OUTPUT_DIR_NODEJS18="${STACK_DIR}/build-nodejs-18"
+readonly OUTPUT_DIR_JAVA8="${STACK_DIR}/build-java-8"
+readonly OUTPUT_DIR_JAVA11="${STACK_DIR}/build-java-11"
+readonly OUTPUT_DIR_JAVA17="${STACK_DIR}/build-java-17"
 
 # shellcheck source=SCRIPTDIR/.util/tools.sh
 source "${PROG_DIR}/.util/tools.sh"
@@ -48,6 +51,9 @@ function main() {
     rm -rf "${OUTPUT_DIR}"
     rm -rf "${OUTPUT_DIR_NODEJS16}"
     rm -rf "${OUTPUT_DIR_NODEJS18}"
+    rm -rf "${OUTPUT_DIR_JAVA8}"
+    rm -rf "${OUTPUT_DIR_JAVA11}"
+    rm -rf "${OUTPUT_DIR_JAVA17}"    
   fi
 
   if ! [[ -f "${OUTPUT_DIR}/build.oci" ]] || ! [[ -f "${OUTPUT_DIR}/run.oci" ]] || ! [[ -f "${OUTPUT_DIR_NODEJS16}/run.oci" ]] || ! [[ -f "${OUTPUT_DIR_NODEJS18}/run.oci" ]]; then
@@ -70,6 +76,12 @@ and
 ${STACK_DIR}/build-nodejs-16/run.oci
 and
 ${STACK_DIR}/build-nodejs-18/run.oci
+and
+${STACK_DIR}/build-java-8/run.oci
+and
+${STACK_DIR}/build-java-11/run.oci
+and
+${STACK_DIR}/build-java-17/run.oci
 if they exist. Otherwise, first runs create.sh to create them.
 
 OPTIONS

--- a/stack-java-11/run.Dockerfile
+++ b/stack-java-11/run.Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi8/openjdk-11-runtime

--- a/stack-java-11/stack.toml
+++ b/stack-java-11/stack.toml
@@ -9,7 +9,7 @@ platforms = ["linux/amd64"]
   dockerfile = "../stack/build.Dockerfile"
   gid = 1000
   shell = "/bin/bash"
-  uid = 1001
+  uid = 1002
 
   [build.args]
 
@@ -18,6 +18,6 @@ platforms = ["linux/amd64"]
   dockerfile = "./run.Dockerfile"
   gid = 1000
   shell = "/bin/bash"
-  uid = 1002
+  uid = 1001
 
   [run.args]

--- a/stack-java-11/stack.toml
+++ b/stack-java-11/stack.toml
@@ -1,0 +1,23 @@
+id = "io.buildpacks.stacks.ubi8"
+homepage = "https://github.com/paketo-community/ubi-base-stack"
+maintainer = "Paketo Community"
+
+platforms = ["linux/amd64"]
+
+[build]
+  description = "base build ubi8 image to support buildpacks"
+  dockerfile = "../stack/build.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1001
+
+  [build.args]
+
+[run]
+  description = "ubi8 java-11 image to support buildpacks"
+  dockerfile = "./run.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1002
+
+  [run.args]

--- a/stack-java-17/run.Dockerfile
+++ b/stack-java-17/run.Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi8/openjdk-17-runtime

--- a/stack-java-17/stack.toml
+++ b/stack-java-17/stack.toml
@@ -9,7 +9,7 @@ platforms = ["linux/amd64"]
   dockerfile = "../stack/build.Dockerfile"
   gid = 1000
   shell = "/bin/bash"
-  uid = 1001
+  uid = 1002
 
   [build.args]
 
@@ -18,6 +18,6 @@ platforms = ["linux/amd64"]
   dockerfile = "./run.Dockerfile"
   gid = 1000
   shell = "/bin/bash"
-  uid = 1002
+  uid = 1001
 
   [run.args]

--- a/stack-java-17/stack.toml
+++ b/stack-java-17/stack.toml
@@ -1,0 +1,23 @@
+id = "io.buildpacks.stacks.ubi8"
+homepage = "https://github.com/paketo-community/ubi-base-stack"
+maintainer = "Paketo Community"
+
+platforms = ["linux/amd64"]
+
+[build]
+  description = "base build ubi8 image to support buildpacks"
+  dockerfile = "../stack/build.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1001
+
+  [build.args]
+
+[run]
+  description = "ubi8 java-17 image to support buildpacks"
+  dockerfile = "./run.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1002
+
+  [run.args]

--- a/stack-java-8/run.Dockerfile
+++ b/stack-java-8/run.Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.access.redhat.com/ubi8/openjdk-8-runtime

--- a/stack-java-8/stack.toml
+++ b/stack-java-8/stack.toml
@@ -1,0 +1,23 @@
+id = "io.buildpacks.stacks.ubi8"
+homepage = "https://github.com/paketo-community/ubi-base-stack"
+maintainer = "Paketo Community"
+
+platforms = ["linux/amd64"]
+
+[build]
+  description = "base build ubi8 image to support buildpacks"
+  dockerfile = "../stack/build.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1001
+
+  [build.args]
+
+[run]
+  description = "ubi8 java-8 image to support buildpacks"
+  dockerfile = "./run.Dockerfile"
+  gid = 1000
+  shell = "/bin/bash"
+  uid = 1002
+
+  [run.args]

--- a/stack-java-8/stack.toml
+++ b/stack-java-8/stack.toml
@@ -9,7 +9,7 @@ platforms = ["linux/amd64"]
   dockerfile = "../stack/build.Dockerfile"
   gid = 1000
   shell = "/bin/bash"
-  uid = 1001
+  uid = 1002
 
   [build.args]
 
@@ -18,6 +18,6 @@ platforms = ["linux/amd64"]
   dockerfile = "./run.Dockerfile"
   gid = 1000
   shell = "/bin/bash"
-  uid = 1002
+  uid = 1001
 
   [run.args]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds the Java Run images to the UBI stack.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Creates the Paketo UBI run images for Java 8, 11, 17 based on the corresponding UBI runtime images. 

Note, this PR is almost entirely based on 'seeing what has been done for the nodejs 16 & 18 images, and doing it again for the Java 8, 11, 17 images' ..  I _think_ I've crossed all the t's and dotted the i's, but would definitely appreciate a fresh set of eyes on the changes, as there's a lot of duplication, which typically leads to the odd instance not being correct.. LGTM, but the more eyes the better =)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
