### PR TITLE
build: temporarily stop publishing to GCR 

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -162,8 +162,8 @@ jobs:
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-21.oci" "docker://${DOCKERHUB_ORG}/run-java-21-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
         sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-21.oci" "docker://${DOCKERHUB_ORG}/run-java-21-${{ steps.registry-repo.outputs.name }}:latest"
 
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-21.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-21-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
-        sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-21.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-21-${{ steps.registry-repo.outputs.name }}:latest"
+        #sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-21.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-21-${{ steps.registry-repo.outputs.name }}:${{ steps.event.outputs.tag }}"
+        #sudo skopeo copy "oci-archive:${GITHUB_WORKSPACE}/run-java-21.oci" "docker://gcr.io/${GCR_PROJECT}/run-java-21-${{ steps.registry-repo.outputs.name }}:latest"
 
   failure:
     name: Alert on Failure


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Temporarily disable publishing to GCR as the paketo-community version seems to have disappeared 3 weeks ago.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
