### PR TITLE
Using build image on all the generated builders on the acceptance/integration tests

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Create stack
         id: create-stack
         run: |
-          ./scripts/create.sh
+          scripts/create.sh
 
       ## build image
       - name: Upload build image
@@ -603,7 +603,7 @@ jobs:
           path: build-java-21
 
       - name: Run Acceptance Tests
-        run: scripts/test.sh
+        run: ./scripts/test.sh
 
   force_release_creation:
     name: Force Release Creation

--- a/buildpack_integration_test.go
+++ b/buildpack_integration_test.go
@@ -120,7 +120,7 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 		}
 
 		for _, stack := range stacks {
-			// Create a copy of the stack to get the value and instead of the pointer
+			// Create a copy of the stack to get the value instead of a pointer
 			stack := stack
 			it(fmt.Sprintf("it should successfully build a nodejs app with node version %d", stack.MajorVersion), func() {
 				buildImageID, _, runImageID, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(stack.AbsPath, RegistryUrl)

--- a/integration/testdata/simple_app/main.go
+++ b/integration/testdata/simple_app/main.go
@@ -15,7 +15,7 @@ func main() {
 		fmt.Fprintln(w, runtime.Version())
 	})
 
-	http.HandleFunc("/node/version", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/nodejs/version", func(w http.ResponseWriter, r *http.Request) {
 
 		cmd := exec.Command("node", "--version")
 

--- a/internal/structs/stack.go
+++ b/internal/structs/stack.go
@@ -2,19 +2,18 @@ package structs
 
 import (
 	"fmt"
-	"path/filepath"
 )
 
 type Stack struct {
 	MajorVersion int
-	AbsPath      string
+	Path         string
 	Engine       string
 }
 
 func NewStack(majorVersion int, engine string, rootDir string) Stack {
 	return Stack{
 		MajorVersion: majorVersion,
-		AbsPath:      filepath.Join(rootDir, fmt.Sprintf("build-%s-%d", engine, majorVersion)),
+		Path:         fmt.Sprintf("build-%s-%d", engine, majorVersion),
 		Engine:       engine,
 	}
 }

--- a/internal/structs/stack.go
+++ b/internal/structs/stack.go
@@ -11,7 +11,6 @@ type Stack struct {
 	Engine       string
 }
 
-// Create a factory for the stack struct
 func NewStack(majorVersion int, engine string, rootDir string) Stack {
 	return Stack{
 		MajorVersion: majorVersion,

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -13,9 +13,9 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/pexec"
 )
 
-func GenerateBuilder(stackPath string, registryUrl string) (buildImageID string, buildImageUrl string, runImageID string, runImageUrl string, builderImageUrl string, err error) {
+func GenerateBuilder(rootDir string, stackPath string, registryUrl string) (buildImageID string, buildImageUrl string, runImageID string, runImageUrl string, builderImageUrl string, err error) {
 
-	buildArchive := filepath.Join(stackPath, "build.oci")
+	buildArchive := filepath.Join(rootDir, "build", "build.oci")
 	buildImageID = fmt.Sprintf("build-image-%s", uuid.NewString())
 	err = archiveToDaemon(buildArchive, buildImageID)
 	if err != nil {
@@ -27,7 +27,7 @@ func GenerateBuilder(stackPath string, registryUrl string) (buildImageID string,
 		return "", "", "", "", "", err
 	}
 
-	runArchive := filepath.Join(stackPath, "run.oci")
+	runArchive := filepath.Join(rootDir, stackPath, "run.oci")
 	runImageID = fmt.Sprintf("run-image-%s", uuid.NewString())
 	err = archiveToDaemon(runArchive, runImageID)
 	if err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -16,7 +16,7 @@ import (
 func GenerateBuilder(stackPath string, registryUrl string) (buildImageID string, buildImageUrl string, runImageID string, runImageUrl string, builderImageUrl string, err error) {
 
 	buildArchive := filepath.Join(stackPath, "build.oci")
-	buildImageID = fmt.Sprintf("build-nodejs-%s", uuid.NewString())
+	buildImageID = fmt.Sprintf("build-image-%s", uuid.NewString())
 	err = archiveToDaemon(buildArchive, buildImageID)
 	if err != nil {
 		return "", "", "", "", "", err
@@ -28,11 +28,12 @@ func GenerateBuilder(stackPath string, registryUrl string) (buildImageID string,
 	}
 
 	runArchive := filepath.Join(stackPath, "run.oci")
-	runImageID = fmt.Sprintf("run-nodejs-%s", uuid.NewString())
+	runImageID = fmt.Sprintf("run-image-%s", uuid.NewString())
 	err = archiveToDaemon(runArchive, runImageID)
 	if err != nil {
 		return "", "", "", "", "", err
 	}
+
 	runImageUrl, err = PushFileToLocalRegistry(runArchive, registryUrl, runImageID)
 	if err != nil {
 		return "", "", "", "", "", err

--- a/nodejs_stack_integration_test.go
+++ b/nodejs_stack_integration_test.go
@@ -69,7 +69,7 @@ func testNodejsStackIntegration(t *testing.T, context spec.G, it spec.S) {
 			// Create a copy of the stack to get the value and instead of the pointer
 			stack := stack
 			it(fmt.Sprintf("it successfully builds an app using Nodejs %d run image", stack.MajorVersion), func() {
-				runArchive := filepath.Join(stack.AbsPath, "run.oci")
+				runArchive := filepath.Join(root, stack.Path, "run.oci")
 				bpUbiRunImageOverrideImageID, err = utils.PushFileToLocalRegistry(runArchive, RegistryUrl, fmt.Sprintf("run-%s-%d-%s", stack.Engine, stack.MajorVersion, uuid.NewString()))
 				Expect(err).NotTo(HaveOccurred())
 

--- a/nodejs_stack_integration_test.go
+++ b/nodejs_stack_integration_test.go
@@ -29,7 +29,6 @@ func testNodejsStackIntegration(t *testing.T, context spec.G, it spec.S) {
 		source string
 		name   string
 
-		// These variables probably are not being used
 		image     occam.Image
 		container occam.Container
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Related issue 
* https://github.com/paketo-community/ubi-base-stack/issues/46
* https://github.com/paketo-community/ubi-base-stack/issues/13

## Summary
<!-- A short explanation of the proposed change -->
On each release we ship one builder image and multiple run images despite we generate from the `create.sh` script multiple build.oci images one for each `engine`, `majorVersion`. Therefor On our integration/acceptance tests, is uneccesary to test all the build.oci images located under each `build-<engine>-<majorVersion>` as we:
* dont ship them on any container registry or on the release assets
* They dont participate on the build process when we build an app, as the builder uses only the one that is pushed on the container registry/release assets https://github.com/paketo-community/builder-ubi-base/blob/47a0a253e7429b1145cef1e35c9eb5aef87c0dc7/builder.toml#L74 

## Use Cases
<!-- An explanation of the use cases your change enables -->
This PR alters the function utils.GenerateBuilder to always point the builder image to `build/build.oci`

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
