### PR TITLE
fix: removing duplicate asset info from release assets

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -852,16 +852,6 @@ jobs:
                 "content_type": "application/gzip"
               },
               {
-                "path": "build-java-21/run.oci",
-                "name": ($repo + "-" + $tag + "-" + "run-java-21.oci"),
-                "content_type": "application/gzip"
-              },
-              {
-                "path": "build-java-21/run.oci.sha256",
-                "name": ($repo + "-" + $tag + "-" + "run-java-21.oci.sha256"),
-                "content_type": "application/gzip"
-              },
-              {
                 "path": "build-nodejs-16/run.oci",
                 "name": ($repo + "-" + $tag + "-" + "run-nodejs-16.oci"),
                 "content_type": "application/gzip"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Related issues
* https://github.com/paketo-community/ubi-base-stack/issues/13
* https://github.com/paketo-community/ubi-base-stack/issues/46


## Summary
<!-- A short explanation of the proposed change -->
This PR fixes the failure on create release. The failure occurred because it was uploading the 21 Java .oci image twice. The duplicate upload asset has been removed

## Use Cases

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
