### PR TITLE
Enabling pack through options.json

### DIFF
--- a/scripts/options.json
+++ b/scripts/options.json
@@ -1,0 +1,3 @@
+{
+  "pack_config_enable_experimental": true
+}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -99,8 +99,6 @@ function main() {
 
   export REGISTRY_URL="localhost:${regport}"
 
-  pack config experimental true
-
   tests::run "${registry_container_id}"
 
   util::tools::cleanup_local_registry "${registry_container_id}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Merge After otherwise it does not pass
* https://github.com/paketo-community/ubi-base-stack/pull/42

## Summary
<!-- A short explanation of the proposed change -->
This PR enables experimental features for pack by using the options.json file.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
