### PR TITLE
specifying max parallel jobs on push image

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: preparation
     strategy:
+      max-parallel: 4
       matrix:
         oci_image: ${{ fromJSON(needs.preparation.outputs.matrix) }}
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
## Related issues
* https://github.com/paketo-community/ubi-base-stack/issues/32

## Summary
<!-- A short explanation of the proposed change -->
Sets the parallel jobs that should run concurrently on push image workflow as the network cant handle it. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
