### PR TITLE
Fetching receipts_show_limit variable from images.json file

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -583,6 +583,13 @@ jobs:
         echo "run_modified=$(jq -c <<< "$(cat run_modified)" )" >> "$GITHUB_OUTPUT"
         echo "run_removed_with_force=$(jq -c <<< "$(cat run_removed_with_force)" )" >> "$GITHUB_OUTPUT"
 
+    - name: Fetch Receipts show limit
+      id: fetch_receipts_show_limit
+      run: |
+        if [[ -f ${{ env.STACKS_FILENAME }} ]]; then
+          echo "receipts_show_limit=$( jq -r '.receipts_show_limit // ""' ${{ env.STACKS_FILENAME }} )" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Create Release Notes
       id: notes
       uses: paketo-community/ubi-base-stack/actions/stack/release-notes@main
@@ -595,7 +602,7 @@ jobs:
         run_packages_added: ${{ steps.release_notes_preparation.outputs.run_added }}
         run_packages_modified: ${{ steps.release_notes_preparation.outputs.run_modified }}
         run_packages_removed_with_force: ${{ steps.release_notes_preparation.outputs.run_removed_with_force }}
-        receipts_show_limit: 16
+        receipts_show_limit: ${{ steps.fetch_receipts_show_limit.outputs.receipts_show_limit }}
         supports_usns: ${{ needs.preparation.outputs.support_usns }}
 
     - name: Setup Release Assets

--- a/images.json
+++ b/images.json
@@ -1,6 +1,7 @@
 {
   "support_usns": false,
   "update_on_new_image": true,
+  "receipts_show_limit": 16,
   "images": [
     {
       "name": "default",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
At the moment, the `show_receipts_limit` variable is being hardcoded. This PR adds functionality for fetching the value of show_receipts_limit from the `images.json` file. In case the value is not available then it sets it to empty and fallbacks to what the create release action has as a value, which is no limit at all.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
