### PR TITLE
Sync push image workflow

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,3 +1,2 @@
 CODEOWNERS
 workflows/create-release.yml
-workflows/push-image.yml

--- a/registries.json
+++ b/registries.json
@@ -1,0 +1,4 @@
+{
+  "dockerhub": true,
+  "GCR": false
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Merge After
* https://github.com/paketo-buildpacks/github-config/pull/950

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* adds a file called `registries.json` which specifies on which registries the stack images should be pushed.
* Syncs the `push-image` workflow

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
