### PR TITLE
Removing functionality for pushing images to docker daemon

### DIFF
--- a/buildpack_integration_test.go
+++ b/buildpack_integration_test.go
@@ -30,8 +30,6 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 		image     occam.Image
 		container occam.Container
 
-		buildImageID    string
-		runImageID      string
 		runImageUrl     string
 		builderImageUrl string
 	)
@@ -47,7 +45,7 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			err = utils.RemoveImages(docker, []string{buildImageID, runImageID, runImageUrl, builderImageUrl})
+			err = utils.RemoveImages(docker, []string{runImageUrl, builderImageUrl})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
@@ -61,7 +59,7 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		it("should successfully build a go app", func() {
-			buildImageID, _, runImageID, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, "build", RegistryUrl)
+			_, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, "build", RegistryUrl)
 			Expect(err).NotTo(HaveOccurred())
 
 			image, _, err = pack.WithNoColor().Build.
@@ -99,7 +97,7 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
 			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			err = utils.RemoveImages(docker, []string{buildImageID, runImageID, runImageUrl, builderImageUrl})
+			err = utils.RemoveImages(docker, []string{runImageUrl, builderImageUrl})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
@@ -116,7 +114,7 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 			// Create a copy of the stack to get the value instead of a pointer
 			stack := stack
 			it(fmt.Sprintf("it should successfully build a nodejs app with node version %d", stack.MajorVersion), func() {
-				buildImageID, _, runImageID, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, stack.Path, RegistryUrl)
+				_, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, stack.Path, RegistryUrl)
 				Expect(err).NotTo(HaveOccurred())
 
 				image, _, err = pack.WithNoColor().Build.

--- a/init_test.go
+++ b/init_test.go
@@ -21,9 +21,7 @@ var RegistryUrl string
 
 var builder struct {
 	imageUrl      string
-	buildImageID  string
 	buildImageUrl string
-	runImageID    string
 	runImageUrl   string
 }
 
@@ -100,7 +98,7 @@ func TestAcceptance(t *testing.T) {
 		Execute(settings.Config.GoDist)
 	Expect(err).NotTo(HaveOccurred())
 
-	builder.buildImageID, builder.buildImageUrl, builder.runImageID, builder.runImageUrl, builder.imageUrl, err = utils.GenerateBuilder(root, "build", RegistryUrl)
+	builder.buildImageUrl, builder.runImageUrl, builder.imageUrl, err = utils.GenerateBuilder(root, "build", RegistryUrl)
 	Expect(err).NotTo(HaveOccurred())
 
 	SetDefaultEventuallyTimeout(120 * time.Second)
@@ -115,7 +113,7 @@ func TestAcceptance(t *testing.T) {
 	lifecycleImageID, err := utils.GetLifecycleImageID(docker, builder.imageUrl)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = utils.RemoveImages(docker, []string{builder.buildImageID, builder.runImageID, lifecycleImageID, builder.runImageUrl, builder.imageUrl})
+	err = utils.RemoveImages(docker, []string{lifecycleImageID, builder.runImageUrl, builder.imageUrl})
 	Expect(err).NotTo(HaveOccurred())
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR removes redundant code, which pushes container images to the docker daemon. That is unnecessary as these images are accessible from the local registry.

This PR is also related to skopeo failing to push images to docker daemon. Specificaly, it resolves the error as the functionality for pushing to docker daemon is removed and, therefore it does not break.

## Related issues
* https://github.com/paketo-community/ubi-base-stack/actions/runs/9591375854

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
