### PR TITLE
doc: add images.json to build image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build-java-8/
 build-java-11/
 build-java-17/
 build-java-21/
+stack/images.json

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -64,6 +64,9 @@ function main() {
 
   tools::install
 
+  # we need to copy images.json for inclusion in the build image
+  cp images.json stack
+
   # if stack or build argument is provided but not both, then throw an error
   if [[ -n "${stack_dir_name}" && ! -n "${build_dir_name}" ]] || [[ ! -n "${stack_dir_name}" && -n "${build_dir_name}" ]]; then
     util::print::error "Both stack-dir and build-dir must be provided"

--- a/stack/build.Dockerfile
+++ b/stack/build.Dockerfile
@@ -1,1 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+USER root
+RUN mkdir -p /etc/buildpacks
+COPY ./images.json /etc/buildpacks/images.json
+RUN chmod 744 /etc/buildpacks/images.json


### PR DESCRIPTION
Refs: https://github.com/paketo-community/ubi-base-stack/issues/88

The plan is to use it in the extensions to find the run images instead of data in the extension.toml file

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Include the images.json file in the base image in the directory /etc/buildpacks

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
