### PR TITLE
Conditionaly testing stacks

### DIFF
--- a/buildpack_integration_test.go
+++ b/buildpack_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	utils "github.com/paketo-community/ubi-base-stack/internal/utils"
@@ -58,63 +59,15 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		it("should successfully build a go app", func() {
-			_, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, "build", RegistryUrl)
-			Expect(err).NotTo(HaveOccurred())
-
-			image, _, err = pack.WithNoColor().Build.
-				WithBuildpacks(
-					settings.Buildpacks.GoDist.Online,
-					settings.Buildpacks.BuildPlan.Online,
-				).
-				WithEnv(map[string]string{
-					"BP_LOG_LEVEL": "DEBUG",
-				}).
-				WithPullPolicy("if-not-present").
-				WithBuilder(builderImageUrl).
-				Execute(name, source)
-			Expect(err).NotTo(HaveOccurred())
-
-			container, err = docker.Container.Run.
-				WithDirect().
-				WithCommand("go").
-				WithCommandArgs([]string{"run", "main.go"}).
-				WithEnv(map[string]string{"PORT": "8080"}).
-				WithPublish("8080").
-				WithPublishAll().
-				Execute(image.ID)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(container).Should(BeAvailable())
-			Eventually(container).Should(Serve(MatchRegexp(`go1.*`)).OnPort(8080))
-
-		})
-	})
-
-	context("When building an app using Node.js stacks", func() {
-
-		it.After(func() {
-			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
-			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
-			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
-			err = utils.RemoveImages(docker, []string{runImageUrl, builderImageUrl})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(os.RemoveAll(source)).To(Succeed())
-		})
-
-		it.Before(func() {
-			name, err = occam.RandomName()
-			Expect(err).NotTo(HaveOccurred())
-
-			source, err = occam.Source(filepath.Join("integration", "testdata", "simple_app"))
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		for _, stack := range settings.Stacks {
-			// Create a copy of the stack to get the value instead of a pointer
+		for _, stack := range settings.ImagesJson.StackImages {
 			stack := stack
-			it(fmt.Sprintf("it should successfully build a nodejs app with node version %d", stack.MajorVersion), func() {
-				_, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, stack.Path, RegistryUrl)
+
+			if stack.Name != "default" {
+				continue
+			}
+
+			it("should successfully build a go app", func() {
+				_, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, "build", RegistryUrl)
 				Expect(err).NotTo(HaveOccurred())
 
 				image, _, err = pack.WithNoColor().Build.
@@ -143,10 +96,71 @@ func testBuildpackIntegration(t *testing.T, context spec.G, it spec.S) {
 				Eventually(container).Should(BeAvailable())
 				Eventually(container).Should(Serve(MatchRegexp(`go1.*`)).OnPort(8080))
 
-				engineVersionEndpoint := fmt.Sprintf("/nodejs/v%d/version", stack.MajorVersion)
-				Eventually(container).Should(Serve(MatchRegexp(fmt.Sprintf(`v%d.*`, stack.MajorVersion))).OnPort(8080).WithEndpoint(engineVersionEndpoint))
 			})
 		}
 	})
 
+	context("When building an app using Node.js stacks", func() {
+
+		it.After(func() {
+			Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			err = utils.RemoveImages(docker, []string{runImageUrl, builderImageUrl})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		it.Before(func() {
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("integration", "testdata", "simple_app"))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		nodejsRegex, _ := regexp.Compile("^nodejs")
+
+		for _, stack := range settings.ImagesJson.StackImages {
+			// Create a copy of the stack to get the value instead of a pointer
+			stack := stack
+
+			if !nodejsRegex.MatchString(stack.Name) {
+				continue
+			}
+
+			it(fmt.Sprintf("it should successfully get the %s version of the run image", stack.Name), func() {
+				_, runImageUrl, builderImageUrl, err = utils.GenerateBuilder(root, stack.OutputDir, RegistryUrl)
+				Expect(err).NotTo(HaveOccurred())
+
+				image, _, err = pack.WithNoColor().Build.
+					WithBuildpacks(
+						settings.Buildpacks.GoDist.Online,
+						settings.Buildpacks.BuildPlan.Online,
+					).
+					WithEnv(map[string]string{
+						"BP_LOG_LEVEL": "DEBUG",
+					}).
+					WithPullPolicy("if-not-present").
+					WithBuilder(builderImageUrl).
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred())
+
+				container, err = docker.Container.Run.
+					WithDirect().
+					WithCommand("go").
+					WithCommandArgs([]string{"run", "main.go"}).
+					WithEnv(map[string]string{"PORT": "8080"}).
+					WithPublish("8080").
+					WithPublishAll().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(MatchRegexp(`go1.*`)).OnPort(8080))
+				nodejsMajorVersion := stack.Name[len("nodejs-"):]
+				Eventually(container).Should(Serve(MatchRegexp(fmt.Sprintf(`v%s.*`, nodejsMajorVersion))).OnPort(8080).WithEndpoint("/nodejs/version"))
+			})
+		}
+	})
 }

--- a/init_test.go
+++ b/init_test.go
@@ -19,6 +19,27 @@ import (
 var root string
 var RegistryUrl string
 
+type StackImages struct {
+	Name                    string `json:"name"`
+	ConfigDir               string `json:"config_dir"`
+	OutputDir               string `json:"output_dir"`
+	BuildImage              string `json:"build_image"`
+	RunImage                string `json:"run_image"`
+	BuildReceiptFilename    string `json:"build_receipt_filename"`
+	RunReceiptFilename      string `json:"run_receipt_filename"`
+	CreateBuildImage        bool   `json:"create_build_image,omitempty"`
+	BaseBuildContainerImage string `json:"base_build_container_image,omitempty"`
+	BaseRunContainerImage   string `json:"base_run_container_image"`
+	Type                    string `json:"type,omitempty"`
+}
+
+type ImagesJson struct {
+	SupportUsns       bool          `json:"support_usns"`
+	UpdateOnNewImage  bool          `json:"update_on_new_image"`
+	ReceiptsShowLimit int           `json:"receipts_show_limit"`
+	Images            []StackImages `json:"images"`
+}
+
 var builder struct {
 	imageUrl      string
 	buildImageUrl string
@@ -53,6 +74,7 @@ var settings struct {
 	}
 
 	Stacks []structs.Stack
+	ImagesJson ImagesJson
 }
 
 func by(_ string, f func()) { f() }
@@ -74,11 +96,17 @@ func TestAcceptance(t *testing.T) {
 	root, err = filepath.Abs(".")
 	Expect(err).ToNot(HaveOccurred())
 
-	file, err := os.Open("./integration.json")
+	integration_json, err := os.Open("./integration.json")
 	Expect(err).NotTo(HaveOccurred())
 
-	Expect(json.NewDecoder(file).Decode(&settings.Config)).To(Succeed())
-	Expect(file.Close()).To(Succeed())
+	Expect(json.NewDecoder(integration_json).Decode(&settings.Config)).To(Succeed())
+	Expect(integration_json.Close()).To(Succeed())
+
+	images_json, err := os.Open("./images.json")
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(json.NewDecoder(images_json).Decode(&settings.ImagesJson)).To(Succeed())
+	Expect(images_json.Close()).To(Succeed())
 
 	buildpackStore := occam.NewBuildpackStore()
 

--- a/integration.json
+++ b/integration.json
@@ -3,8 +3,5 @@
   "ubi-nodejs-extension": "github.com/paketo-community/ubi-nodejs-extension",
   "nodejs": "github.com/paketo-buildpacks/nodejs",
   "go-dist": "github.com/paketo-buildpacks/go-dist",
-  "nodejs-major-versions": [
-    16, 18, 20
-  ],
   "setup_local_registy": true
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR introduces 2 changes:
1. Refactors the code to test the images that exist on `images.json` file and not from what is specified on the integration.json file
2. Adds functionality to test only the images that exist on `TEST_ONLY_STACKS` env variable, only if `TEST_ONLY_STACKS` has been set and is not empty, which is being set from the test.sh script (related PR with the implementation PR https://github.com/paketo-community/ubi-base-stack/pull/97)

## Related issues
* https://github.com/paketo-community/ubi-base-stack/issues/5


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
