### PR TITLE
Refactor: Copying images.json file on the base stack, only if the file exists

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -64,15 +64,15 @@ function main() {
 
   tools::install
 
-  # we need to copy images.json for inclusion in the build image
-  cp images.json stack
-
   # if stack or build argument is provided but not both, then throw an error
   if [[ -n "${stack_dir_name}" && ! -n "${build_dir_name}" ]] || [[ ! -n "${stack_dir_name}" && -n "${build_dir_name}" ]]; then
     util::print::error "Both stack-dir and build-dir must be provided"
   elif [[ -n "${stack_dir_name}" && -n "${build_dir_name}" ]]; then
     stack::create "${ROOT_DIR}/${stack_dir_name}" "${ROOT_DIR}/${build_dir_name}" "${flags[@]}"
   elif [ -f "${IMAGES_JSON}" ]; then
+    # we need to copy images.json for inclusion in the build image
+    cp images.json stack
+
     jq -c '.images[]' "${IMAGES_JSON}" | while read -r image; do
       config_dir=$(echo "${image}" | jq -r '.config_dir')
       output_dir=$(echo "${image}" | jq -r '.output_dir')
@@ -97,7 +97,6 @@ OPTIONS
   --build-dir       Provide the build directory relative to the root directory. The default value is 'build'.
 USAGE
 }
-
 
 function tools::install() {
   util::tools::jam::install \


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR places the code that copies the `images.json` file to the base stack, inside the if statement. That way we ensure that `images.json` is always available, avoiding any unexpected errors.

Practically this PR is a minor refactor of this PR: https://github.com/paketo-community/ubi-base-stack/pull/94

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
