### PR TITLE
Minor fixes for create release and push image workflow

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,3 +1,4 @@
 CODEOWNERS
 workflows/create-release.yml
 workflows/push-image.yml
+/workflows/test-pull-request.yml

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -599,6 +599,11 @@ jobs:
         stacks: ${{ fromJSON(needs.preparation.outputs.stacks) }}
         arch: ${{ fromJSON(needs.preparation.outputs.architectures) }}
     steps:
+    - name: Checkout With History
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # gets full history
+
     - name: Download Current Receipt(s)
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         # Strip off the org and slash from repo name
         # paketo-buildpacks/repo-name --> repo-name
-        echo "repo_name=$(echo "${{ github.repository }}" | sed 's/^.*\///')" >> "$GITHUB_OUTPUT"
+        echo "repo_name=$(echo "${{ github.repository }}" | sed 's/^.*\///' | sed 's/\-stack$//')" >> "$GITHUB_OUTPUT"
 
     - name: Set matrix
       id: set-matrix


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR:
* excludes the `test-pull-request` workflow file from github-config sync.
* Increments the tag, which is written on the release notes, by adding the checkout with history step
* removes the `stack` prefix from the push image workflow

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
